### PR TITLE
Feat/10-상태전환-스케줄러-및-Kafka-이벤트-구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 .DS_Storessl/
 *.jks
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out/
 .DS_Storessl/
 *.jks
 .DS_Store
+
+application-local.yml

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
+    testImplementation 'org.awaitility:awaitility:4.2.2'
+    testRuntimeOnly 'com.h2database:h2'
     testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/finlearn/seasonservice/SeasonServiceApplication.java
+++ b/src/main/java/com/finlearn/seasonservice/SeasonServiceApplication.java
@@ -2,12 +2,13 @@ package com.finlearn.seasonservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class SeasonServiceApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(SeasonServiceApplication.class, args);
     }
-
 }

--- a/src/main/java/com/finlearn/seasonservice/application/SeasonService.java
+++ b/src/main/java/com/finlearn/seasonservice/application/SeasonService.java
@@ -5,15 +5,22 @@ import com.finlearn.common.exception.ConflictException;
 import com.finlearn.common.exception.NotFoundException;
 import com.finlearn.seasonservice.domain.Season;
 import com.finlearn.seasonservice.domain.SeasonParticipant;
+import com.finlearn.seasonservice.domain.event.SeasonEndedEvent;
+import com.finlearn.seasonservice.domain.event.SeasonStartedEvent;
 import com.finlearn.seasonservice.domain.repository.SeasonParticipantRepository;
 import com.finlearn.seasonservice.domain.repository.SeasonRepository;
 import com.finlearn.seasonservice.domain.vo.PassedCategory;
 import com.finlearn.seasonservice.domain.vo.SeasonStatus;
+import com.finlearn.seasonservice.infrastructure.client.AchievementClient;
+import com.finlearn.seasonservice.infrastructure.client.RankingClient;
+import com.finlearn.seasonservice.infrastructure.kafka.SeasonEventProducer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Slf4j
@@ -24,6 +31,9 @@ public class SeasonService {
 
     private final SeasonRepository seasonRepository;
     private final SeasonParticipantRepository participantRepository;
+    private final SeasonEventProducer seasonEventProducer;
+    private final AchievementClient achievementClient;
+    private final RankingClient rankingClient;
 
     // ────────────────────────────────────────────────────────────────
     // 시즌 조회
@@ -62,7 +72,7 @@ public class SeasonService {
             throw new ConflictException("이미 해당 시즌에 참여 중입니다.");
         }
 
-        // 신규 참여: 업적 및 랭킹 보너스 없음 (RankingFinalized 이벤트 수신 시 갱신)
+        // 신규 참여: 업적/랭킹 보너스 없음 (RankingFinalized 이벤트 수신 시 갱신)
         SeasonParticipant participant = SeasonParticipant.create(
                 season, userId, userNickname, passedCategories, 0, 0
         );
@@ -72,5 +82,135 @@ public class SeasonService {
                 seasonId, userId, participant.getTotalSeedMoney());
 
         return participant;
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    // 스케줄러 호출 메서드
+    // ────────────────────────────────────────────────────────────────
+
+    @Transactional
+    public int startUpcomingSeasons() {
+        LocalDate today = LocalDate.now();
+        List<Season> targets = seasonRepository.findAllUpcomingToStart(today);
+
+        for (Season season : targets) {
+            season.start();
+            seasonRepository.save(season);
+
+            seasonEventProducer.publishSeasonStarted(new SeasonStartedEvent(
+                    season.getSeasonId(),
+                    season.getSeasonNumber(),
+                    season.getStartDate(),
+                    season.getEndDate()
+            ));
+
+            log.info("[SeasonService] 시즌 시작: seasonId={}, seasonNumber={}",
+                    season.getSeasonId(), season.getSeasonNumber());
+        }
+        return targets.size();
+    }
+
+    @Transactional
+    public int endActiveSeasons() {
+        LocalDate today = LocalDate.now();
+        List<Season> targets = seasonRepository.findAllActiveToEnd(today);
+
+        for (Season season : targets) {
+            season.end();
+            seasonRepository.save(season);
+
+            seasonEventProducer.publishSeasonEnded(new SeasonEndedEvent(
+                    season.getSeasonId(),
+                    season.getSeasonNumber()
+            ));
+
+            log.info("[SeasonService] 시즌 종료: seasonId={}, seasonNumber={}",
+                    season.getSeasonId(), season.getSeasonNumber());
+        }
+        return targets.size();
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    // Kafka 이벤트 처리
+    // ────────────────────────────────────────────────────────────────
+
+    /**
+     * RankingFinalized 이벤트 수신 후 처리
+     * 종료된 시즌 기준으로 다음 시즌 참여자들의 시드머니 보너스를 갱신
+     */
+    @Transactional
+    public void processRankingFinalized(UUID endedSeasonId) {
+        log.info("[SeasonService] RankingFinalized 처리 시작: endedSeasonId={}", endedSeasonId);
+
+        Optional<Season> nextSeasonOpt = seasonRepository.findByStatus(SeasonStatus.UPCOMING);
+        if (nextSeasonOpt.isEmpty()) {
+            log.warn("[SeasonService] UPCOMING 상태의 다음 시즌이 없어 보너스 산정을 건너뜁니다.");
+            return;
+        }
+
+        Season nextSeason = nextSeasonOpt.get();
+        List<SeasonParticipant> nextParticipants =
+                participantRepository.findAllBySeasonId(nextSeason.getSeasonId());
+
+        for (SeasonParticipant participant : nextParticipants) {
+            UUID userId = participant.getUserId().getValue();
+
+            int achievementBonus = calculateAchievementBonus(userId, endedSeasonId);
+            int rankingBonus = calculateRankingBonus(userId, endedSeasonId);
+
+            participant.applyBonuses(achievementBonus, rankingBonus);
+            participantRepository.save(participant);
+
+            log.debug("[SeasonService] 시드머니 보너스 적용: userId={}, achievement={}, ranking={}, total={}",
+                    userId, achievementBonus, rankingBonus, participant.getTotalSeedMoney());
+        }
+
+        log.info("[SeasonService] RankingFinalized 처리 완료: 총 {}명 업데이트", nextParticipants.size());
+    }
+
+    /**
+     * UserProfileUpdated 이벤트 수신 후 처리
+     * season_participants의 user_nickname VO 스냅샷 갱신
+     */
+    @Transactional
+    public void syncUserNickname(UUID userId, String newNickname) {
+        List<SeasonParticipant> participants = participantRepository.findAllByUserId(userId);
+        participants.forEach(p -> p.updateNickname(newNickname));
+        participantRepository.saveAll(participants);
+        log.info("[SeasonService] 닉네임 스냅샷 갱신 완료: userId={}, nickname={}, count={}",
+                userId, newNickname, participants.size());
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    // 시드머니 보너스 산정
+    // ────────────────────────────────────────────────────────────────
+
+    /**
+     * 전 시즌 업적 달성 수 기반 보너스 산정 (단위: 만원)
+     * 0개: 0
+     * 1~3개: 200
+     * 4~7개: 500
+     * 8개 이상: 1000
+     */    private int calculateAchievementBonus(UUID userId, UUID seasonId) {
+        int count = achievementClient.getAchievementCount(userId, seasonId);
+        if (count == 0) return 0;
+        if (count <= 3) return 200;
+        if (count <= 7) return 500;
+        return 1000;
+    }
+
+    /**
+     * 전 시즌 랭킹 순위 기반 보너스 산정 (단위: 만원)
+     * 1위: 200
+     * 2~5위: 100
+     * 6~20위: 50
+     * 21위 이상: 0
+     */    private int calculateRankingBonus(UUID userId, UUID seasonId) {
+        Integer rank = rankingClient.getRank(userId, seasonId);
+        if (rank == null) return 0;
+        if (rank == 1) return 200;
+        if (rank <= 5) return 100;
+        if (rank <= 20) return 50;
+        return 0;
     }
 }

--- a/src/main/java/com/finlearn/seasonservice/application/SeasonService.java
+++ b/src/main/java/com/finlearn/seasonservice/application/SeasonService.java
@@ -136,7 +136,7 @@ public class SeasonService {
 
     /**
      * RankingFinalized 이벤트 수신 후 처리
-     * 종료된 시즌 기준으로 다음 시즌 참여자들의 시드머니 보너스를 갱신
+     * 종료된 시즌 기준으로 다음 시즌(UPCOMING) 참여자들의 시드머니 보너스를 갱신
      */
     @Transactional
     public void processRankingFinalized(UUID endedSeasonId) {
@@ -159,25 +159,27 @@ public class SeasonService {
             int rankingBonus = calculateRankingBonus(userId, endedSeasonId);
 
             participant.applyBonuses(achievementBonus, rankingBonus);
-            participantRepository.save(participant);
 
             log.debug("[SeasonService] 시드머니 보너스 적용: userId={}, achievement={}, ranking={}, total={}",
                     userId, achievementBonus, rankingBonus, participant.getTotalSeedMoney());
         }
+
+        // 개별 save → saveAll 일괄 처리로 DB 라운드트립 최소화
+        participantRepository.saveAll(nextParticipants);
 
         log.info("[SeasonService] RankingFinalized 처리 완료: 총 {}명 업데이트", nextParticipants.size());
     }
 
     /**
      * UserProfileUpdated 이벤트 수신 후 처리
-     * season_participants의 user_nickname VO 스냅샷 갱신
+     * season_participants의 user_nickname 스냅샷 갱신
      */
     @Transactional
-    public void syncUserNickname(UUID userId, String newNickname) {
+    public void syncUserProfile(UUID userId, String newNickname) {
         List<SeasonParticipant> participants = participantRepository.findAllByUserId(userId);
         participants.forEach(p -> p.updateNickname(newNickname));
         participantRepository.saveAll(participants);
-        log.info("[SeasonService] 닉네임 스냅샷 갱신 완료: userId={}, nickname={}, count={}",
+        log.info("[SeasonService] 유저 프로필 스냅샷 갱신 완료: userId={}, nickname={}, count={}",
                 userId, newNickname, participants.size());
     }
 
@@ -191,7 +193,8 @@ public class SeasonService {
      * 1~3개: 200
      * 4~7개: 500
      * 8개 이상: 1000
-     */    private int calculateAchievementBonus(UUID userId, UUID seasonId) {
+     */
+    private int calculateAchievementBonus(UUID userId, UUID seasonId) {
         int count = achievementClient.getAchievementCount(userId, seasonId);
         if (count == 0) return 0;
         if (count <= 3) return 200;
@@ -205,7 +208,8 @@ public class SeasonService {
      * 2~5위: 100
      * 6~20위: 50
      * 21위 이상: 0
-     */    private int calculateRankingBonus(UUID userId, UUID seasonId) {
+     */
+    private int calculateRankingBonus(UUID userId, UUID seasonId) {
         Integer rank = rankingClient.getRank(userId, seasonId);
         if (rank == null) return 0;
         if (rank == 1) return 200;

--- a/src/main/java/com/finlearn/seasonservice/infrastructure/client/AchievementClient.java
+++ b/src/main/java/com/finlearn/seasonservice/infrastructure/client/AchievementClient.java
@@ -1,0 +1,63 @@
+package com.finlearn.seasonservice.infrastructure.client;
+
+import com.finlearn.seasonservice.infrastructure.client.dto.AchievementCountResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AchievementClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${internal.achievement-service.url}")
+    private String achievementServiceUrl;
+
+    /**
+     * 특정 시즌에서 유저의 달성 업적 수 조회
+     * GET /api/v1/achievements/me/count
+     *
+     * @param userId   유저 ID
+     * @param seasonId 조회 대상 시즌 ID
+     * @return 업적 달성 수 (조회 실패 시 0 반환)
+     */
+    public int getAchievementCount(UUID userId, UUID seasonId) {
+        try {
+            String url = UriComponentsBuilder
+                    .fromHttpUrl(achievementServiceUrl)
+                    .path("/api/v1/achievements/me/count")
+                    .queryParam("seasonId", seasonId.toString())
+                    .build()
+                    .toUriString();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-User-Id", userId.toString());
+            HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<AchievementCountResponse> response =
+                    restTemplate.exchange(url, HttpMethod.GET, entity, AchievementCountResponse.class);
+
+            AchievementCountResponse body = response.getBody();
+            if (body == null || body.getAchievementCount() == null) {
+                return 0;
+            }
+            return body.getAchievementCount();
+        } catch (RestClientException e) {
+            log.warn("[AchievementClient] 업적 수 조회 실패 (userId={}, seasonId={}): {}",
+                    userId, seasonId, e.getMessage());
+            return 0;
+        }
+    }
+}

--- a/src/main/java/com/finlearn/seasonservice/infrastructure/client/AchievementClient.java
+++ b/src/main/java/com/finlearn/seasonservice/infrastructure/client/AchievementClient.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
@@ -25,29 +24,19 @@ public class AchievementClient {
     @Value("${internal.achievement-service.url}")
     private String achievementServiceUrl;
 
-    /**
-     * 특정 시즌에서 유저의 달성 업적 수 조회
-     * GET /api/v1/achievements/me/count
-     *
-     * @param userId   유저 ID
-     * @param seasonId 조회 대상 시즌 ID
-     * @return 업적 달성 수 (조회 실패 시 0 반환)
-     */
+    // 업적 달성 수 조회 (조회 실패 시 0 반환)
     public int getAchievementCount(UUID userId, UUID seasonId) {
         try {
             String url = UriComponentsBuilder
                     .fromHttpUrl(achievementServiceUrl)
-                    .path("/api/v1/achievements/me/count")
+                    .path("/internal/v1/achievements/count")
+                    .queryParam("userId", userId.toString())
                     .queryParam("seasonId", seasonId.toString())
                     .build()
                     .toUriString();
 
-            HttpHeaders headers = new HttpHeaders();
-            headers.set("X-User-Id", userId.toString());
-            HttpEntity<Void> entity = new HttpEntity<>(headers);
-
             ResponseEntity<AchievementCountResponse> response =
-                    restTemplate.exchange(url, HttpMethod.GET, entity, AchievementCountResponse.class);
+                    restTemplate.exchange(url, HttpMethod.GET, HttpEntity.EMPTY, AchievementCountResponse.class);
 
             AchievementCountResponse body = response.getBody();
             if (body == null || body.getAchievementCount() == null) {

--- a/src/main/java/com/finlearn/seasonservice/infrastructure/client/RankingClient.java
+++ b/src/main/java/com/finlearn/seasonservice/infrastructure/client/RankingClient.java
@@ -1,0 +1,62 @@
+package com.finlearn.seasonservice.infrastructure.client;
+
+import com.finlearn.seasonservice.infrastructure.client.dto.RankingGradeResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${internal.ranking-service.url}")
+    private String rankingServiceUrl;
+
+    /**
+     * 특정 시즌, 유저의 최종 순위 조회
+     * GET /api/v1/rankings/seasons/{seasonId}/me
+     *
+     * @param userId   유저 ID
+     * @param seasonId 조회 대상 시즌 ID
+     * @return 순위 (조회 실패 또는 미참여 시 null 반환)
+     */
+    public Integer getRank(UUID userId, UUID seasonId) {
+        try {
+            String url = UriComponentsBuilder
+                    .fromHttpUrl(rankingServiceUrl)
+                    .path("/api/v1/rankings/seasons/{seasonId}/me")
+                    .buildAndExpand(seasonId.toString())
+                    .toUriString();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-User-Id", userId.toString());
+            HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<RankingGradeResponse> response =
+                    restTemplate.exchange(url, HttpMethod.GET, entity, RankingGradeResponse.class);
+
+            RankingGradeResponse body = response.getBody();
+            if (body == null) {
+                return null;
+            }
+            return body.getRank();
+        } catch (RestClientException e) {
+            log.warn("[RankingClient] 랭킹 순위 조회 실패 (userId={}, seasonId={}): {}",
+                    userId, seasonId, e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/finlearn/seasonservice/infrastructure/client/RankingClient.java
+++ b/src/main/java/com/finlearn/seasonservice/infrastructure/client/RankingClient.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-
 import java.util.UUID;
 
 @Slf4j
@@ -26,12 +25,9 @@ public class RankingClient {
     private String rankingServiceUrl;
 
     /**
-     * 특정 시즌, 유저의 최종 순위 조회
-     * GET /api/v1/rankings/seasons/{seasonId}/me
-     *
-     * @param userId   유저 ID
-     * @param seasonId 조회 대상 시즌 ID
-     * @return 순위 (조회 실패 또는 미참여 시 null 반환)
+     * TODO: ranking-service 내부 API 구현
+     * 특정 시즌, 유저의 ALL 랭킹 순위 조회
+     * ranking-service 내부 API 구현 전까지 항상 null 반환 (보너스 0 적용)
      */
     public Integer getRank(UUID userId, UUID seasonId) {
         try {

--- a/src/main/java/com/finlearn/seasonservice/infrastructure/client/dto/AchievementCountResponse.java
+++ b/src/main/java/com/finlearn/seasonservice/infrastructure/client/dto/AchievementCountResponse.java
@@ -1,0 +1,16 @@
+package com.finlearn.seasonservice.infrastructure.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AchievementCountResponse {
+
+    private UUID userId;
+    private UUID seasonId;
+    private Integer achievementCount;
+}

--- a/src/main/java/com/finlearn/seasonservice/infrastructure/client/dto/RankingGradeResponse.java
+++ b/src/main/java/com/finlearn/seasonservice/infrastructure/client/dto/RankingGradeResponse.java
@@ -1,0 +1,16 @@
+package com.finlearn.seasonservice.infrastructure.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RankingGradeResponse {
+
+    private UUID userId;
+    private UUID seasonId;
+    private Integer rank;
+}

--- a/src/main/java/com/finlearn/seasonservice/infrastructure/config/RestTemplateConfig.java
+++ b/src/main/java/com/finlearn/seasonservice/infrastructure/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.finlearn.seasonservice.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/finlearn/seasonservice/infrastructure/kafka/SeasonEventConsumer.java
+++ b/src/main/java/com/finlearn/seasonservice/infrastructure/kafka/SeasonEventConsumer.java
@@ -1,0 +1,55 @@
+package com.finlearn.seasonservice.infrastructure.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.finlearn.seasonservice.application.SeasonService;
+import com.finlearn.seasonservice.infrastructure.kafka.event.RankingFinalizedEvent;
+import com.finlearn.seasonservice.infrastructure.kafka.event.UserProfileUpdatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * 시즌 도메인 이벤트 Kafka 수신 클래스
+ *
+ * common KafkaConfig의 JsonDeserializer<Object> 기반으로 메시지를 수신
+ * 리스너 메서드는 Object 타입으로 받은 뒤 ObjectMapper.convertValue()로 이벤트 타입으로 변환
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SeasonEventConsumer {
+
+    private final SeasonService seasonService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * ranking.finalized 이벤트 수신
+     * 랭킹 확정 완료 후 다음 시즌 참여자 시드머니 보너스 산정
+     */
+    @KafkaListener(topics = "ranking.finalized", groupId = "season-service")
+    public void handleRankingFinalized(Object payload) {
+        try {
+            log.info("[Kafka] RankingFinalized 이벤트 수신");
+            RankingFinalizedEvent event = objectMapper.convertValue(payload, RankingFinalizedEvent.class);
+            seasonService.processRankingFinalized(event.getSeasonId());
+        } catch (Exception e) {
+            log.error("[Kafka] RankingFinalized 이벤트 처리 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * user.profile-updated 이벤트 수신
+     * 닉네임 변경 시 season_participants의 user_nickname VO 스냅샷 갱신
+     */
+    @KafkaListener(topics = "user.profile-updated", groupId = "season-service")
+    public void handleUserProfileUpdated(Object payload) {
+        try {
+            log.info("[Kafka] UserProfileUpdated 이벤트 수신");
+            UserProfileUpdatedEvent event = objectMapper.convertValue(payload, UserProfileUpdatedEvent.class);
+            seasonService.syncUserNickname(event.getUserId(), event.getNickname());
+        } catch (Exception e) {
+            log.error("[Kafka] UserProfileUpdated 이벤트 처리 실패: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/finlearn/seasonservice/infrastructure/kafka/SeasonEventConsumer.java
+++ b/src/main/java/com/finlearn/seasonservice/infrastructure/kafka/SeasonEventConsumer.java
@@ -9,12 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
-/**
- * 시즌 도메인 이벤트 Kafka 수신 클래스
- *
- * common KafkaConfig의 JsonDeserializer<Object> 기반으로 메시지를 수신
- * 리스너 메서드는 Object 타입으로 받은 뒤 ObjectMapper.convertValue()로 이벤트 타입으로 변환
- */
+import java.util.Map;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -27,29 +23,37 @@ public class SeasonEventConsumer {
      * ranking.finalized 이벤트 수신
      * 랭킹 확정 완료 후 다음 시즌 참여자 시드머니 보너스 산정
      */
-    @KafkaListener(topics = "ranking.finalized", groupId = "season-service")
-    public void handleRankingFinalized(Object payload) {
+    @KafkaListener(
+            topics = "${kafka.topics.ranking.finalized}",
+            groupId = "${spring.kafka.consumer.group-id}"
+    )
+    public void handleRankingFinalized(Map<String, Object> payload) {
         try {
             log.info("[Kafka] RankingFinalized 이벤트 수신");
             RankingFinalizedEvent event = objectMapper.convertValue(payload, RankingFinalizedEvent.class);
             seasonService.processRankingFinalized(event.getSeasonId());
         } catch (Exception e) {
-            log.error("[Kafka] RankingFinalized 이벤트 처리 실패: {}", e.getMessage(), e);
+            log.error("[Kafka] RankingFinalized 이벤트 처리 실패 - 재시도 유도: {}", e.getMessage(), e);
+            throw new RuntimeException("[Kafka] RankingFinalized 처리 실패", e);
         }
     }
 
     /**
      * user.profile-updated 이벤트 수신
-     * 닉네임 변경 시 season_participants의 user_nickname VO 스냅샷 갱신
+     * season_participants의 user_nickname VO 스냅샷 갱신
      */
-    @KafkaListener(topics = "user.profile-updated", groupId = "season-service")
-    public void handleUserProfileUpdated(Object payload) {
+    @KafkaListener(
+            topics = "${kafka.topics.user.updated}",
+            groupId = "${spring.kafka.consumer.group-id}"
+    )
+    public void handleUserProfileUpdated(Map<String, Object> payload) {
         try {
             log.info("[Kafka] UserProfileUpdated 이벤트 수신");
             UserProfileUpdatedEvent event = objectMapper.convertValue(payload, UserProfileUpdatedEvent.class);
-            seasonService.syncUserNickname(event.getUserId(), event.getNickname());
+            seasonService.syncUserProfile(event.getUserId(), event.getNickname());
         } catch (Exception e) {
-            log.error("[Kafka] UserProfileUpdated 이벤트 처리 실패: {}", e.getMessage(), e);
+            log.error("[Kafka] UserProfileUpdated 이벤트 처리 실패 - 재시도 유도: {}", e.getMessage(), e);
+            throw new RuntimeException("[Kafka] UserProfileUpdated 처리 실패", e);
         }
     }
 }

--- a/src/main/java/com/finlearn/seasonservice/infrastructure/kafka/SeasonEventProducer.java
+++ b/src/main/java/com/finlearn/seasonservice/infrastructure/kafka/SeasonEventProducer.java
@@ -1,0 +1,48 @@
+package com.finlearn.seasonservice.infrastructure.kafka;
+
+import com.finlearn.seasonservice.domain.event.SeasonEndedEvent;
+import com.finlearn.seasonservice.domain.event.SeasonStartedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+// 시즌 도메인 이벤트 Kafka 발행 클래스
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SeasonEventProducer {
+
+    private static final String TOPIC_SEASON_STARTED = "season.started";
+    private static final String TOPIC_SEASON_ENDED = "season.ended";
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void publishSeasonStarted(SeasonStartedEvent event) {
+        log.info("[Kafka] SeasonStarted 이벤트 발행: seasonId={}, seasonNumber={}",
+                event.getSeasonId(), event.getSeasonNumber());
+        kafkaTemplate.send(TOPIC_SEASON_STARTED, event.getSeasonId().toString(), event)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("[Kafka] SeasonStarted 이벤트 발행 실패: {}", ex.getMessage());
+                    } else {
+                        log.debug("[Kafka] SeasonStarted 이벤트 발행 완료: offset={}",
+                                result.getRecordMetadata().offset());
+                    }
+                });
+    }
+
+    public void publishSeasonEnded(SeasonEndedEvent event) {
+        log.info("[Kafka] SeasonEnded 이벤트 발행: seasonId={}, seasonNumber={}",
+                event.getSeasonId(), event.getSeasonNumber());
+        kafkaTemplate.send(TOPIC_SEASON_ENDED, event.getSeasonId().toString(), event)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("[Kafka] SeasonEnded 이벤트 발행 실패: {}", ex.getMessage());
+                    } else {
+                        log.debug("[Kafka] SeasonEnded 이벤트 발행 완료: offset={}",
+                                result.getRecordMetadata().offset());
+                    }
+                });
+    }
+}

--- a/src/main/java/com/finlearn/seasonservice/infrastructure/kafka/SeasonEventProducer.java
+++ b/src/main/java/com/finlearn/seasonservice/infrastructure/kafka/SeasonEventProducer.java
@@ -4,24 +4,27 @@ import com.finlearn.seasonservice.domain.event.SeasonEndedEvent;
 import com.finlearn.seasonservice.domain.event.SeasonStartedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
-// 시즌 도메인 이벤트 Kafka 발행 클래스
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class SeasonEventProducer {
 
-    private static final String TOPIC_SEASON_STARTED = "season.started";
-    private static final String TOPIC_SEASON_ENDED = "season.ended";
+    @Value("${kafka.topics.season.started}")
+    private String topicSeasonStarted;
+
+    @Value("${kafka.topics.season.ended}")
+    private String topicSeasonEnded;
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
     public void publishSeasonStarted(SeasonStartedEvent event) {
         log.info("[Kafka] SeasonStarted 이벤트 발행: seasonId={}, seasonNumber={}",
                 event.getSeasonId(), event.getSeasonNumber());
-        kafkaTemplate.send(TOPIC_SEASON_STARTED, event.getSeasonId().toString(), event)
+        kafkaTemplate.send(topicSeasonStarted, event.getSeasonId().toString(), event)
                 .whenComplete((result, ex) -> {
                     if (ex != null) {
                         log.error("[Kafka] SeasonStarted 이벤트 발행 실패: {}", ex.getMessage());
@@ -35,7 +38,7 @@ public class SeasonEventProducer {
     public void publishSeasonEnded(SeasonEndedEvent event) {
         log.info("[Kafka] SeasonEnded 이벤트 발행: seasonId={}, seasonNumber={}",
                 event.getSeasonId(), event.getSeasonNumber());
-        kafkaTemplate.send(TOPIC_SEASON_ENDED, event.getSeasonId().toString(), event)
+        kafkaTemplate.send(topicSeasonEnded, event.getSeasonId().toString(), event)
                 .whenComplete((result, ex) -> {
                     if (ex != null) {
                         log.error("[Kafka] SeasonEnded 이벤트 발행 실패: {}", ex.getMessage());

--- a/src/main/java/com/finlearn/seasonservice/infrastructure/kafka/event/RankingFinalizedEvent.java
+++ b/src/main/java/com/finlearn/seasonservice/infrastructure/kafka/event/RankingFinalizedEvent.java
@@ -1,0 +1,20 @@
+package com.finlearn.seasonservice.infrastructure.kafka.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.UUID;
+
+/**
+ * 랭킹 서비스로부터 수신
+ * 시즌 종료 후 랭킹 확정 + 뱃지 지급 완료 시 발행
+ * 수신 후: 다음 시즌 참여자 시드머니 산정 시작
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RankingFinalizedEvent {
+
+    private UUID seasonId;
+    private Integer seasonNumber;
+}

--- a/src/main/java/com/finlearn/seasonservice/infrastructure/kafka/event/UserProfileUpdatedEvent.java
+++ b/src/main/java/com/finlearn/seasonservice/infrastructure/kafka/event/UserProfileUpdatedEvent.java
@@ -1,0 +1,21 @@
+package com.finlearn.seasonservice.infrastructure.kafka.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.UUID;
+
+/**
+ * 유저 서비스로부터 수신
+ * 닉네임 또는 프로필 이미지 변경 시 발행
+ * 수신 후: season_participants의 user_nickname VO 스냅샷 갱신
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileUpdatedEvent {
+
+    private UUID userId;
+    private String nickname;
+    private String profileImage;
+}

--- a/src/main/java/com/finlearn/seasonservice/infrastructure/persistence/SeasonJpaRepository.java
+++ b/src/main/java/com/finlearn/seasonservice/infrastructure/persistence/SeasonJpaRepository.java
@@ -10,7 +10,8 @@ import java.util.UUID;
 
 public interface SeasonJpaRepository extends JpaRepository<Season, UUID> {
 
-    Optional<Season> findByStatus(SeasonStatus status);
+    // 특정 상태의 시즌을 하나 조회
+    Optional<Season> findFirstByStatusOrderBySeasonNumberAsc(SeasonStatus status);
 
     List<Season> findAllByStatusOrderBySeasonNumberDesc(SeasonStatus status);
 

--- a/src/main/java/com/finlearn/seasonservice/infrastructure/persistence/SeasonRepositoryImpl.java
+++ b/src/main/java/com/finlearn/seasonservice/infrastructure/persistence/SeasonRepositoryImpl.java
@@ -28,7 +28,8 @@ public class SeasonRepositoryImpl implements SeasonRepository {
 
     @Override
     public Optional<Season> findByStatus(SeasonStatus status) {
-        return seasonJpaRepository.findByStatus(status);
+        // findByStatus 대신 findFirstByStatus 사용 — 동일 status 다중 존재 시 예외 방지
+        return seasonJpaRepository.findFirstByStatusOrderBySeasonNumberAsc(status);
     }
 
     @Override

--- a/src/main/java/com/finlearn/seasonservice/infrastructure/scheduler/SeasonScheduler.java
+++ b/src/main/java/com/finlearn/seasonservice/infrastructure/scheduler/SeasonScheduler.java
@@ -1,0 +1,41 @@
+package com.finlearn.seasonservice.infrastructure.scheduler;
+
+import com.finlearn.seasonservice.application.SeasonService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SeasonScheduler {
+
+    private final SeasonService seasonService;
+
+    /**
+     * 매일 자정에 실행되는 스케줄러
+     * 순서 보장: 종료(ACTIVE → ENDED) 먼저 처리 후 시작(UPCOMING → ACTIVE) 처리
+     * 같은 날 종료/시작이 겹치는 경우, 종료를 먼저 처리해야 새 시즌이 ACTIVE 상태가 됨
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    public void processSeasonTransitions() {
+        log.info("[Scheduler] 시즌 전환 스케줄러 실행");
+
+        // 이전 시즌 먼저 종료 처리
+        try {
+            int endedCount = seasonService.endActiveSeasons();
+            log.info("[Scheduler] {}개 시즌 종료 처리 완료 (ACTIVE → ENDED)", endedCount);
+        } catch (Exception e) {
+            log.error("[Scheduler] 시즌 종료 처리 중 오류 발생: {}", e.getMessage(), e);
+        }
+
+        // 이후 새 시즌 시작 처리
+        try {
+            int startedCount = seasonService.startUpcomingSeasons();
+            log.info("[Scheduler] {}개 시즌 시작 처리 완료 (UPCOMING → ACTIVE)", startedCount);
+        } catch (Exception e) {
+            log.error("[Scheduler] 시즌 시작 처리 중 오류 발생: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -5,6 +5,10 @@ spring:
     url: jdbc:postgresql://finlearn-postgres:5432/seasondb
     username: ${DB_USERNAME:postgres}
     password: ${DB_PASSWORD:postgres}
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
   data:
     redis:
       host: finlearn-redis
@@ -22,6 +26,14 @@ internal:
     url: http://finlearn-achievement-service:8085
   ranking-service:
     url: http://finlearn-ranking-service:8086
+
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://zipkin:9411/api/v2/spans
 
 loki:
   url: http://host.docker.internal:3100/loki/api/v1/push

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,10 +11,10 @@ spring:
   config:
     import: optional:configserver:http://localhost:8888
   datasource:
-    url: jdbc:postgresql://localhost:5432/seasondb
+    url: jdbc:postgresql://${DB_HOST:localhost}:5432/${DB_NAME:seasondb}
     driver-class-name: org.postgresql.Driver
     username: ${DB_USERNAME:postgres}
-    password: ${DB_PASSWORD:}
+    password: ${DB_PASSWORD:postgres}
 
 eureka:
   instance:
@@ -23,10 +23,29 @@ eureka:
     register-with-eureka: true
     fetch-registry: true
     service-url:
-      defaultZone: http://localhost:8761/eureka/
+      defaultZone: http://${EUREKA_HOST:localhost}:8761/eureka/
 
 internal:
   achievement-service:
-    url: http://localhost:8085
+    url: ${ACHIEVEMENT_SERVICE_URL:http://localhost:8085}
   ranking-service:
-    url: http://localhost:8086
+    url: ${RANKING_SERVICE_URL:http://localhost:8086}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    health:
+      show-details: always
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+  tracing:
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://localhost:9411/api/v2/spans

--- a/src/test/java/com/finlearn/seasonservice/infrastructure/kafka/SeasonEventConsumerTest.java
+++ b/src/test/java/com/finlearn/seasonservice/infrastructure/kafka/SeasonEventConsumerTest.java
@@ -1,0 +1,76 @@
+package com.finlearn.seasonservice.infrastructure.kafka;
+
+import com.finlearn.seasonservice.application.SeasonService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+@ActiveProfiles("kafka-test")
+@EmbeddedKafka(
+        partitions = 1,
+        topics = {"test-ranking-finalized", "test-user-updated"}
+)
+@DirtiesContext
+@Import(SeasonEventProducerTest.TestKafkaConsumer.class)
+@DisplayName("[Kafka] SeasonEventConsumer 통합 테스트")
+class SeasonEventConsumerTest {
+
+    @Autowired
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @MockitoBean
+    private SeasonService seasonService;
+
+    private static final UUID SEASON_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID USER_ID   = UUID.fromString("00000000-0000-0000-0001-000000000001");
+
+    @Test
+    @DisplayName("ranking.finalized 토픽 수신 시 processRankingFinalized() 가 호출된다")
+
+    void handleRankingFinalized_callsProcessRankingFinalized() {
+        // given
+        Map<String, Object> payload = Map.of(
+                "seasonId", SEASON_ID.toString(),
+                "seasonNumber", 1
+        );
+
+        // when
+        kafkaTemplate.send("test-ranking-finalized", SEASON_ID.toString(), payload);
+
+        // then
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(seasonService).processRankingFinalized(SEASON_ID));
+    }
+
+    @Test
+    @DisplayName("user.profile-updated 토픽 수신 시 syncUserProfile() 이 호출된다")
+    void handleUserProfileUpdated_callsSyncUserProfile() {
+        // given
+        Map<String, Object> payload = Map.of(
+                "userId", USER_ID.toString(),
+                "nickname", "새닉네임",
+                "profileImage", "https://example.com/image.png"
+        );
+
+        // when
+        kafkaTemplate.send("test-user-updated", USER_ID.toString(), payload);
+
+        // then
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(seasonService).syncUserProfile(eq(USER_ID), eq("새닉네임")));
+    }
+}

--- a/src/test/java/com/finlearn/seasonservice/infrastructure/kafka/SeasonEventProducerTest.java
+++ b/src/test/java/com/finlearn/seasonservice/infrastructure/kafka/SeasonEventProducerTest.java
@@ -1,0 +1,109 @@
+package com.finlearn.seasonservice.infrastructure.kafka;
+
+import com.finlearn.seasonservice.domain.event.SeasonEndedEvent;
+import com.finlearn.seasonservice.domain.event.SeasonStartedEvent;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.ContainerTestUtils;
+import org.springframework.stereotype.Component;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import java.time.LocalDate;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("kafka-test")
+@EmbeddedKafka(
+        partitions = 1,
+        topics = {"test-season-started", "test-season-ended"}
+)
+@DirtiesContext
+@Import(SeasonEventProducerTest.TestKafkaConsumer.class)
+@DisplayName("[Kafka] SeasonEventProducer 통합 테스트")
+class SeasonEventProducerTest {
+
+    @Autowired
+    private SeasonEventProducer producer;
+
+    @Autowired
+    private TestKafkaConsumer testConsumer;
+
+    @Autowired
+    private KafkaListenerEndpointRegistry listenerRegistry;
+
+    /** 테스트용 컨슈머가 파티션에 할당될 때까지 대기 */
+    @BeforeEach
+    void waitForConsumerReady() throws Exception {
+        for (var container : listenerRegistry.getListenerContainers()) {
+            ContainerTestUtils.waitForAssignment(container, 1);
+        }
+    }
+
+    @Test
+    @DisplayName("SeasonStarted 이벤트 발행 시 test-season-started 토픽에서 수신된다")
+    void publishSeasonStarted_messageReceivedOnTopic() throws InterruptedException {
+        // given
+        SeasonStartedEvent event = new SeasonStartedEvent(
+                UUID.randomUUID(), 3, LocalDate.now(), LocalDate.now().plusMonths(6));
+
+        // when
+        producer.publishSeasonStarted(event);
+
+        // then: 최대 5초 대기
+        boolean received = testConsumer.startedLatch.await(5, TimeUnit.SECONDS);
+        assertThat(received).isTrue();
+        assertThat(testConsumer.lastStartedRecord).isNotNull();
+    }
+
+    @Test
+    @DisplayName("SeasonEnded 이벤트 발행 시 test-season-ended 토픽에서 수신된다")
+    void publishSeasonEnded_messageReceivedOnTopic() throws InterruptedException {
+        // given
+        SeasonEndedEvent event = new SeasonEndedEvent(UUID.randomUUID(), 2);
+
+        // when
+        producer.publishSeasonEnded(event);
+
+        // then: 최대 5초 대기
+        boolean received = testConsumer.endedLatch.await(5, TimeUnit.SECONDS);
+        assertThat(received).isTrue();
+        assertThat(testConsumer.lastEndedRecord).isNotNull();
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // 이벤트 수신 여부 확인용
+    // ─────────────────────────────────────────────────────────────
+
+    @Component
+    static class TestKafkaConsumer {
+
+        final CountDownLatch startedLatch = new CountDownLatch(1);
+        final CountDownLatch endedLatch   = new CountDownLatch(1);
+
+        ConsumerRecord<?, ?> lastStartedRecord;
+        ConsumerRecord<?, ?> lastEndedRecord;
+
+        @KafkaListener(topics = "test-season-started", groupId = "test-producer-group")
+        void onSeasonStarted(ConsumerRecord<?, ?> record) {
+            lastStartedRecord = record;
+            startedLatch.countDown();
+        }
+
+        @KafkaListener(topics = "test-season-ended", groupId = "test-producer-group")
+        void onSeasonEnded(ConsumerRecord<?, ?> record) {
+            lastEndedRecord = record;
+            endedLatch.countDown();
+        }
+    }
+}

--- a/src/test/resources/application-kafka-test.yml
+++ b/src/test/resources/application-kafka-test.yml
@@ -1,0 +1,60 @@
+# ============================================================
+# Kafka 통합 테스트 전용
+# config-server 없이 @EmbeddedKafka로 테스트 실행
+#   - PostgreSQL → H2 인메모리 DB
+#   - Kafka → @EmbeddedKafka 브로커 자동 주입
+#   - Eureka / Config-Server / Tracing 비활성화
+# ============================================================
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL;NON_KEYWORDS=VALUE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: false
+  kafka:
+    bootstrap-servers: ${spring.embedded.kafka.brokers}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      group-id: test-season-service
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+    properties:
+      security.protocol: PLAINTEXT
+      spring.json.trusted.packages: "*"
+  cloud:
+    config:
+      enabled: false
+kafka:
+  topics:
+    season:
+      started: test-season-started
+      ended: test-season-ended
+    ranking:
+      finalized: test-ranking-finalized
+      updated: test-ranking-updated
+    user:
+      updated: test-user-updated
+eureka:
+  client:
+    enabled: false
+management:
+  tracing:
+    enabled: false
+internal:
+  achievement-service:
+    url: http://localhost:9999
+  ranking-service:
+    url: http://localhost:9999
+logging:
+  level:
+    com.finlearn: WARN
+    org.springframework.kafka: WARN

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  테스트 전용 Logback 설정
+  - Loki 어펜더 완전 제거 (localhost:3100 연결 시도 차단)
+  - 테스트 실행 속도 향상
+-->
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 테스트 로그는 WARN 이상만 출력 (노이즈 제거) -->
+    <root level="WARN">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+    <!-- 우리 코드 로그만 INFO로 확인 -->
+    <logger name="com.finlearn" level="INFO" additivity="false">
+        <appender-ref ref="CONSOLE" />
+    </logger>
+
+    <!-- Kafka 관련 불필요한 로그 억제 -->
+    <logger name="org.springframework.kafka" level="WARN" />
+    <logger name="org.apache.kafka" level="WARN" />
+
+</configuration>


### PR DESCRIPTION
## 🌱 설명
매일 자정 시즌 상태를 자동으로 전환하는 스케줄러를 구현했습니다.
타 서비스와의 데이터 정합성 및 이벤트 기반 로직 처리를 위한 Kafka 메시징 기능을 추가했습니다.

### 주요 작업 내용
> 시즌 자동 전환 스케줄러 
- 종료일이 지난 시즌을 ACTIVE → ENDED로 먼저 처리
- 시작일이 된 시즌을 UPCOMING → ACTIVE로 전환하여 순서 보장
- 각 전환 단계는 독립적으로 처리되어, 예외 발생 시에도 전체 프로세스에 영향을 주지 않도록 함 
> Kafka 이벤트 발행 및 수신
- 시즌 상태 전환 시 season.started, season.ended 이벤트 발행 
- ranking.finalized 수신 시, 전 시즌의 업적 및 랭킹에 따라 UPCOMING 시즌 참여자의 시드머니를 차등 지급
- user.profile-updated 수신 시, 시즌 참여 기록에 저장된 유저 닉네임 스냅샷을 최신화

## 📌 관련 이슈
> close #10, #11

## 💻 커밋 유형
- [x] feat : 새로운 기능 추가

## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

