### PR TITLE
[Chore] Config Server 설정 연동 및 빌드 실패 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,5 @@ out/
 ### VS Code ###
 .vscode/
 
-.DS_Store
+.DS_Storessl/
+*.jks

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -3,18 +3,8 @@ spring:
     import: optional:configserver:http://finlearn-config-server:8888
   datasource:
     url: jdbc:postgresql://finlearn-postgres:5432/seasondb
-    driver-class-name: org.postgresql.Driver
-    username: postgres
-    password: postgres
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: false
-  kafka:
-    bootstrap-servers: finlearn-kafka:9092
-    consumer:
-      group-id: season-service
-      auto-offset-reset: earliest
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
   data:
     redis:
       host: finlearn-redis
@@ -27,23 +17,11 @@ eureka:
     service-url:
       defaultZone: http://finlearn-eureka:8761/eureka/
 
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health,info,prometheus
-  tracing:
-    sampling:
-      probability: 1.0
-  zipkin:
-    tracing:
-      endpoint: http://host.docker.internal:9411/api/v2/spans
-
-loki:
-  url: http://host.docker.internal:3100/loki/api/v1/push
-
 internal:
   achievement-service:
     url: http://finlearn-achievement-service:8085
   ranking-service:
     url: http://finlearn-ranking-service:8086
+
+loki:
+  url: http://host.docker.internal:3100/loki/api/v1/push

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,55 +4,29 @@ server:
 spring:
   application:
     name: season-service
+  profiles:
+    active: local
+    group:
+      docker: "kafka,topics"
   config:
     import: optional:configserver:http://localhost:8888
   datasource:
-    url: jdbc:postgresql://${DB_HOST:localhost}:5432/${DB_NAME:seasondb}
+    url: jdbc:postgresql://localhost:5432/seasondb
     driver-class-name: org.postgresql.Driver
     username: ${DB_USERNAME:postgres}
-    password: ${DB_PASSWORD:postgres}
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-  kafka:
-    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
-    consumer:
-      group-id: season-service
-      auto-offset-reset: earliest
-  data:
-    redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
+    password: ${DB_PASSWORD:}
 
 eureka:
   instance:
-    prefer-ip-address: false
-    hostname: localhost
-    instance-id: ${spring.application.name}:${server.port}
+    prefer-ip-address: true
   client:
     register-with-eureka: true
     fetch-registry: true
     service-url:
-      defaultZone: http://${EUREKA_URL1:localhost}:8761/eureka/
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health,info,prometheus
-  endpoint:
-    health:
-      show-details: always
-  tracing:
-    sampling:
-      probability: 1.0
+      defaultZone: http://localhost:8761/eureka/
 
 internal:
   achievement-service:
-    url: ${ACHIEVEMENT_SERVICE_URL:http://localhost:8085}
+    url: http://localhost:8085
   ranking-service:
-    url: ${RANKING_SERVICE_URL:http://localhost:8086}
+    url: http://localhost:8086


### PR DESCRIPTION
## 🌱 설명
- 신규 `configs` repository 기반 설정 구조에 맞춰 Config Server 연동 설정을 반영했습니다.
- 서비스 실행 시 중앙 설정 저장소에서 필요한 설정을 정상적으로 가져오도록 수정했습니다.
- 설정 분리 과정에서 발생한 빌드 실패를 해결했습니다.
- 로컬 및 Docker Compose 환경에서 전체 서비스 빌드가 성공하도록 설정을 보완했습니다.

## 📌 관련 이슈
- close #13 

---

## 💻 커밋 유형
- [ ] feat : 새로운 기능 추가
- [x] fix : 버그 수정
- [ ] !hotfix : 급하게 치명적인 버그 수정
- [ ] refactor : 리팩토링
- [x] chore : 빌드 설정, 의존성 업데이트 등
- [ ] docs : 문서 수정
- [ ] comment : 필요한 주석 추가 및 변경
- [ ] rename : 파일 또는 폴더 명을 수정하거나 옮기는 작업
- [ ] remove : 파일을 삭제하는 작업
- [ ] test : 테스트 코드, 리팩토링 테스트 코드 추가

---

## 📝 체크리스트
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일을 확인했나요?
- [x] 불필요한 파일이 포함되지 않았나요?
- [x] Config Server 설정을 정상적으로 가져오나요?
- [x] 서비스 단독 빌드가 성공하나요?
- [x] Docker Compose 전체 빌드가 성공하나요?
- [x] Eureka에 정상 등록되나요?
- [x] Actuator health endpoint가 정상 응답하나요?