### PR TITLE
Refactor/16-성능개선-및-내부API-연동

### DIFF
--- a/src/main/java/com/finlearn/seasonservice/application/SeasonService.java
+++ b/src/main/java/com/finlearn/seasonservice/application/SeasonService.java
@@ -22,6 +22,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 @Slf4j
 @Service
@@ -136,7 +137,7 @@ public class SeasonService {
 
     /**
      * RankingFinalized 이벤트 수신 후 처리
-     * 종료된 시즌 기준으로 다음 시즌(UPCOMING) 참여자들의 시드머니 보너스를 갱신
+     * 종료된 시즌 기준으로 다음 시즌 참여자들의 시드머니 보너스를 갱신
      */
     @Transactional
     public void processRankingFinalized(UUID endedSeasonId) {
@@ -152,19 +153,20 @@ public class SeasonService {
         List<SeasonParticipant> nextParticipants =
                 participantRepository.findAllBySeasonId(nextSeason.getSeasonId());
 
-        for (SeasonParticipant participant : nextParticipants) {
-            UUID userId = participant.getUserId().getValue();
+        // 참여자별 보너스 산정을 병렬로 실행 — HTTP 호출(achievement, ranking)을 동시에 처리
+        List<CompletableFuture<Void>> futures = nextParticipants.stream()
+                .map(participant -> CompletableFuture.runAsync(() -> {
+                    UUID userId = participant.getUserId().getValue();
+                    int achievementBonus = calculateAchievementBonus(userId, endedSeasonId);
+                    int rankingBonus = calculateRankingBonus(userId, endedSeasonId);
+                    participant.applyBonuses(achievementBonus, rankingBonus);
+                    log.debug("[SeasonService] 시드머니 보너스 적용: userId={}, achievement={}, ranking={}, total={}",
+                            userId, achievementBonus, rankingBonus, participant.getTotalSeedMoney());
+                }))
+                .toList();
 
-            int achievementBonus = calculateAchievementBonus(userId, endedSeasonId);
-            int rankingBonus = calculateRankingBonus(userId, endedSeasonId);
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
 
-            participant.applyBonuses(achievementBonus, rankingBonus);
-
-            log.debug("[SeasonService] 시드머니 보너스 적용: userId={}, achievement={}, ranking={}, total={}",
-                    userId, achievementBonus, rankingBonus, participant.getTotalSeedMoney());
-        }
-
-        // 개별 save → saveAll 일괄 처리로 DB 라운드트립 최소화
         participantRepository.saveAll(nextParticipants);
 
         log.info("[SeasonService] RankingFinalized 처리 완료: 총 {}명 업데이트", nextParticipants.size());

--- a/src/main/java/com/finlearn/seasonservice/infrastructure/client/RankingClient.java
+++ b/src/main/java/com/finlearn/seasonservice/infrastructure/client/RankingClient.java
@@ -4,9 +4,6 @@ import com.finlearn.seasonservice.infrastructure.client.dto.RankingGradeResponse
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
@@ -25,24 +22,21 @@ public class RankingClient {
     private String rankingServiceUrl;
 
     /**
-     * TODO: ranking-service 내부 API 구현
-     * 특정 시즌, 유저의 ALL 랭킹 순위 조회
-     * ranking-service 내부 API 구현 전까지 항상 null 반환 (보너스 0 적용)
+     * 시즌 종료 후 확정된 유저의 ALL 랭킹 순위 조회
+     * ranking-service 내부 API: GET /internal/v1/rankings/seasons/{seasonId}/rank?userId={userId}
+     * 랭킹 확정 전이거나 조회 실패 시 null 반환 → 보너스 0 적용
      */
     public Integer getRank(UUID userId, UUID seasonId) {
         try {
             String url = UriComponentsBuilder
                     .fromHttpUrl(rankingServiceUrl)
-                    .path("/api/v1/rankings/seasons/{seasonId}/me")
+                    .path("/internal/v1/rankings/seasons/{seasonId}/rank")
+                    .queryParam("userId", userId.toString())
                     .buildAndExpand(seasonId.toString())
                     .toUriString();
 
-            HttpHeaders headers = new HttpHeaders();
-            headers.set("X-User-Id", userId.toString());
-            HttpEntity<Void> entity = new HttpEntity<>(headers);
-
             ResponseEntity<RankingGradeResponse> response =
-                    restTemplate.exchange(url, HttpMethod.GET, entity, RankingGradeResponse.class);
+                    restTemplate.getForEntity(url, RankingGradeResponse.class);
 
             RankingGradeResponse body = response.getBody();
             if (body == null) {


### PR DESCRIPTION
## 🌱 설명

시드머니 산정(`processRankingFinalized`) 성능 개선 및 ranking-service 내부 API 연동을 완료합니다.

**문제**
- `rankingClient.getRank()`: ranking-service 내부 API 미구현으로 항상 null 반환 (순위 보너스 0 고정)
- `processRankingFinalized()`: 참여자 N명 × HTTP 2회 = 최대 2N회 직렬 호출 → 처리 시간 선형 증가

**해결**

ranking-service — 순위 조회 내부 API 구현 

## 📌 관련 이슈
> close #16

## 💻 커밋 유형
- [x] refactor : 리팩토링


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


